### PR TITLE
Fix spelling and whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ If you are running this project locally, you'll need to set up tunnels for Slack
 You'll likely want to test events coming to your server without going through the actions on your Slack team.  [Postman](https://www.getpostman.com/) is a useful tool you can use to recreate requests sent from Slack to your server. This is especially helpful for events like user join, where the workflow to recreate the event requires quite a bit of set up.
 
 ## Let's get started :tada:
-* **[Section 1: ~~Steal~~ Build This Bot](docs/Section-1.md)** :point_left:  
-* [Section 2: Create a Slack App and Bot User](docs/Section-2.md)  
-* [Section 3: Subscribe to Events](docs/Section-3.md)  
+* **[Section 1: ~~Steal~~ Build This Bot](docs/Section-1.md)** :point_left:
+* [Section 2: Create a Slack App and Bot User](docs/Section-2.md)
+* [Section 3: Subscribe to Events](docs/Section-3.md)
 * [Section 4: App Credentials](docs/Section-4.md)
 * [Section 5: Make it Go](docs/Section-5.md)
 
@@ -71,8 +71,8 @@ You'll likely want to test events coming to your server without going through th
 ### Documentation
 
 ##### Slack Documentation
-* [Getting started with Slack apps](https://api.slack.com/slack-apps)  
-* [Slack Events API documentation](https://api.slack.com/events)  
+* [Getting started with Slack apps](https://api.slack.com/slack-apps)
+* [Slack Events API documentation](https://api.slack.com/events)
 * [Slack Web API documentation](https://api.slack.com/web)
 
 ##### Documentation for Tools

--- a/app.py
+++ b/app.py
@@ -21,7 +21,7 @@ def _event_handler(event_type, slack_event):
     Parameters
     ----------
     event_type : str
-        type of event recieved from Slack
+        type of event received from Slack
     slack_event : dict
         JSON response from a Slack reaction event
 
@@ -132,7 +132,7 @@ def hears():
         make_response(message, 403, {"X-Slack-No-Retry": 1})
 
     # ====== Process Incoming Events from Slack ======= #
-    # If the incoming request is an Event we've subcribed to
+    # If the incoming request is an Event we've subscribed to
     if "event" in slack_event:
         event_type = slack_event["event"]["type"]
         # Then handle the event by event_type and have your bot respond

--- a/bot.py
+++ b/bot.py
@@ -10,12 +10,12 @@ from slackclient import SlackClient
 # To remember which teams have authorized your app and what tokens are
 # associated with each team, we can store this information in memory on
 # as a global object. When your bot is out of development, it's best to
-# save this in a more persistant memory store.
+# save this in a more persistent memory store.
 authed_teams = {}
 
 
 class Bot(object):
-    """ Instanciates a Bot object to handle Slack onboarding interactions."""
+    """ Instantiates a Bot object to handle Slack onboarding interactions."""
     def __init__(self):
         super(Bot, self).__init__()
         self.name = "pythonboardingbot"
@@ -31,13 +31,13 @@ class Bot(object):
         self.verification = os.environ.get("VERIFICATION_TOKEN")
 
         # NOTE: Python-slack requires a client connection to generate
-        # an oauth token. We can connect to the client without authenticating
+        # an OAuth token. We can connect to the client without authenticating
         # by passing an empty string as a token and then reinstantiating the
         # client with a valid OAuth token once we have one.
         self.client = SlackClient("")
         # We'll use this dictionary to store the state of each message object.
-        # In a production envrionment you'll likely want to store this more
-        # persistantly in  a database.
+        # In a production environment you'll likely want to store this more
+        # persistently in  a database.
         self.messages = {}
 
     def auth(self, code):
@@ -115,7 +115,7 @@ class Bot(object):
         # of for the team id we've got.
         if self.messages.get(team_id):
             # Then we'll update the message dictionary with a key for the
-            # user id we've recieved and a value of a new message object
+            # user id we've received and a value of a new message object
             self.messages[team_id].update({user_id: message.Message()})
         else:
             # If there aren't any message for that team, we'll add a dictionary
@@ -181,7 +181,7 @@ class Bot(object):
 
     def update_pin(self, team_id, user_id):
         """
-        Update onboarding welcome message after recieving a "pin_added"
+        Update onboarding welcome message after receiving a "pin_added"
         event from Slack. Update timestamp for welcome message.
 
         Parameters

--- a/docs/Section-1.md
+++ b/docs/Section-1.md
@@ -10,7 +10,7 @@ This file handles all incoming requests from Slack. In this file, we'll import t
 First, you'll want to create a Flask app in [`app.py`](./../app.py).
 Then you'll need to add a couple routes:
 - **`"/install"`** a route that renders an installation page where users can add your Slack app to their team
-- **`"/thanks"`** a route that renders a thank you page to let users know your app has been sucessfully installed.
+- **`"/thanks"`** a route that renders a thank you page to let users know your app has been successfully installed.
     - This route will be the endpoint of the `redirect URL` where Slack will send a temporary authorization code. We'll exchange that code for an OAuth token here, using our `bot` object's `auth` method.
 - **`"/listening"`** a route that listens for all incoming requests from Slack.
     - This route will be the endpoint of the `request URL` where Slack will send all Events your app is subscribed to.
@@ -49,12 +49,12 @@ This file contains a python class for creating `message` objects. Creating `mess
 ### Other Stuff
 
 #### [Templates Folder](./../templates)
-You'll need some HTML for your [installation](./../templates/install.html) and [thank you](./../templates/thanks.html) pages. Once you create this folder, we'll use Jinja templates and add the [Add to Slack](https://api.slack.com/docs/slack-button) button to allow users to install our app. The [thank you page](./../templates/thanks.html) lets users know that the app has been sucessfully installed.
+You'll need some HTML for your [installation](./../templates/install.html) and [thank you](./../templates/thanks.html) pages. Once you create this folder, we'll use Jinja templates and add the [Add to Slack](https://api.slack.com/docs/slack-button) button to allow users to install our app. The [thank you page](./../templates/thanks.html) lets users know that the app has been successfully installed.
 
 #### [welcome.json](./../welcome.json)
 This is a JSON file of message attachments used in the `message.py` file to create the onboarding welcome message our bot will send to new users.
 
 
 ---
-**Next [Section 2: Create a Slack App and Bot User](./../docs/Section-2.md)**  
-**Previous [README](./../README.md)**  
+**Next [Section 2: Create a Slack App and Bot User](./../docs/Section-2.md)**
+**Previous [README](./../README.md)**

--- a/docs/Section-2.md
+++ b/docs/Section-2.md
@@ -25,5 +25,5 @@ Let's get ourselves a shiny new **Bot User** so our app can communicate on Slack
 ![add_bot_user](https://cloud.githubusercontent.com/assets/4828352/20548602/c67f367a-b0d9-11e6-85eb-b2069120da1e.png)
 
 ---
-**Next [Section 3: Subscribe to Events](./../docs/Section-3.md)**  
-**Previous [Section 1: ~~Steal~~ Build This Bot](./../docs/Section-1.md)**  
+**Next [Section 3: Subscribe to Events](./../docs/Section-3.md)**
+**Previous [Section 1: ~~Steal~~ Build This Bot](./../docs/Section-1.md)**

--- a/docs/Section-3.md
+++ b/docs/Section-3.md
@@ -21,5 +21,5 @@ After you've subscribed to all the events your app will need, make sure to **Sav
 ![save_changes](https://cloud.githubusercontent.com/assets/4828352/20575405/fca754dc-b16d-11e6-880d-5eb8dd5d5196.png)
 
 ---
-**Next [Section 4:  App Credentials](./../docs/Section-4.md)**  
-**Previous [Section 2: Create a Slack App and Bot User](./../docs/Section-2.md)**  
+**Next [Section 4:  App Credentials](./../docs/Section-4.md)**
+**Previous [Section 2: Create a Slack App and Bot User](./../docs/Section-2.md)**

--- a/docs/Section-4.md
+++ b/docs/Section-4.md
@@ -19,5 +19,5 @@ export VERIFICATION_TOKEN='xxxXXXxxXXxxX'
 Our app will grab these secrets from our environment.
 
 ---
-**Next [Section 5: Make it Go](./../docs/Section-5.md)**  
-**Previous [Section 3: Subscribe to Events](./../docs/Section-3.md)**  
+**Next [Section 5: Make it Go](./../docs/Section-5.md)**
+**Previous [Section 3: Subscribe to Events](./../docs/Section-3.md)**

--- a/docs/Section-5.md
+++ b/docs/Section-5.md
@@ -30,8 +30,8 @@ After you've enabled events, you'll need to add a **redirect URL** in your app's
 
 ![redirect_url_thanks](https://cloud.githubusercontent.com/assets/4828352/20549300/d5aa215e-b0df-11e6-9796-3cb6fb1da7b4.png)
 
-Now your app is ready to be installed on a Slack team! :tada:
+Now your app is ready to be installed on a Slack team. Go ahead and hit that `https://<yourtempsubdomain>.ngrok.io/` URL to install!  :tada:
 
 ---
-**Next [More Info: README](./../README.md)**  
-**Previous [Section 4: App Credentials](./../docs/Section-4.md)**  
+**Next [More Info: README](./../README.md)**
+**Previous [Section 4: App Credentials](./../docs/Section-4.md)**

--- a/message.py
+++ b/message.py
@@ -8,7 +8,7 @@ import yaml
 
 class Message(object):
     """
-    Instanciates a Message object to create and manage
+    Instantiates a Message object to create and manage
     Slack onboarding messages.
     """
     def __init__(self):


### PR DESCRIPTION
This PR fixes trailing whitespace and spelling throughout the docs/docstrings and also adds a line giving more context about how to install the app/bot. This PR is a superset of #1 and #2, helps address #3, and IMHO provides a more user-friendly suggestion than hitting the OAuth endpoint directly (#5). 

cc: @karishay 